### PR TITLE
Update Carousel.js

### DIFF
--- a/lib/Carousel.js
+++ b/lib/Carousel.js
@@ -158,7 +158,7 @@ class Carousel extends PureComponent {
   }
 
   componentWillUnmount() {
-    if (this.slider) this.slider.destroy();
+    if (this.slider && this.slider.destroy) this.slider.destroy();
   }
 
   render() {


### PR DESCRIPTION
There are cases where slider and destroy is null. When we didn't handle this situation, when react lazy was included, this line would explode.