### PR TITLE
fix: fix the import of tiny-slider

### DIFF
--- a/lib/Carousel.js
+++ b/lib/Carousel.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { tns } from 'tiny-slider/src/tiny-slider';
+import { tns } from 'tiny-slider';
 import { ObjectsEqual, ChildrenEqual } from './utils';
 
 /**


### PR DESCRIPTION
this will make cjs loader correctly follow 'tiny-slider' package.json "main"