### PR TITLE
add support for next.js by avoiding tns initialization in SSR

### DIFF
--- a/lib/Carousel.js
+++ b/lib/Carousel.js
@@ -1,6 +1,5 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { tns } from 'tiny-slider/src/tiny-slider';
 import { ObjectsEqual, ChildrenEqual } from './utils';
 
 /**
@@ -69,7 +68,8 @@ class Carousel extends PureComponent {
       },
     };
 
-    this.slider = tns(this.mergedSettings);
+    // dynamic import of 'tiny-slider' to support SSR
+    this.slider = require('tiny-slider').tns(this.mergedSettings);
     if (this.hasForwardedRef) {
       let o = this.ref && this.ref.current;
       if (o) {
@@ -140,7 +140,9 @@ class Carousel extends PureComponent {
 
   /* LIFECYCLE EVENTS */
   componentDidMount() {
-    this.build(this.props.settings);
+    // avoid crash when SSR
+    if(window)
+      this.build(this.props.settings);
   }
 
   componentDidUpdate(prevProps) {


### PR DESCRIPTION
1. changed tiny-slider to dynamic import
2. avoid loading tns in SSR
3. update import from `tiny-slider/src/tiny-slider` to `tiny-slider` so it can correctly follow tiny-slider's package.json "main"