### PR TITLE
fix the import of tiny-slider

### DIFF
--- a/lib/Carousel.js
+++ b/lib/Carousel.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { tns } from 'tiny-slider/src/tiny-slider';
+import { tns } from 'tiny-slider';
 import { ObjectsEqual, ChildrenEqual } from './utils';
 
 /**


### PR DESCRIPTION
<img width="749" alt="Screen Shot 2022-08-07 at 9 08 25 PM" src="https://user-images.githubusercontent.com/26269173/183337303-3198a2b8-7f56-45b5-a2ff-929a70753a33.png">

This is for fixing this error.

tiny-slider's src/ is written in ES: https://github.com/ganlanyuan/tiny-slider/blob/master/src/tiny-slider.js